### PR TITLE
Adding endpoint to authenticate for a specific role

### DIFF
--- a/src/main/java/com/damienwesterman/defensedrill/security/web/RestAuthenticationController.java
+++ b/src/main/java/com/damienwesterman/defensedrill/security/web/RestAuthenticationController.java
@@ -86,7 +86,7 @@ public class RestAuthenticationController {
      * User wants to authenticate and get a JWT for a specific role.
      * <br><br>
      * An example for this might be someone who is a mobile user granted ROLE_USER and ROLE_ADMIN.
-     * The user wants the extended expiration for their JWT using ROLE_USER, so thsi endpoint allows
+     * The user wants the extended expiration for their JWT using ROLE_USER, so this endpoint allows
      * them to specify which role they want to authenticate for.
      *
      * @param login User Login DTO

--- a/src/main/java/com/damienwesterman/defensedrill/security/web/RestAuthenticationController.java
+++ b/src/main/java/com/damienwesterman/defensedrill/security/web/RestAuthenticationController.java
@@ -26,14 +26,22 @@
 
 package com.damienwesterman.defensedrill.security.web;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.damienwesterman.defensedrill.security.service.DrillUserDetailsService;
@@ -44,12 +52,14 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/authenticate")
 public class RestAuthenticationController {
+
     private final JwtService jwtService;
     private final AuthenticationManager authenticationManager;
     private final DrillUserDetailsService userDetailsService;
 
-    @PostMapping("/authenticate")
+    @PostMapping
     public ResponseEntity<String> authenticate(@RequestBody LoginDTO login) {
         // Have to surround in a try/catch, otherwise Spring will follow default security response
         try {
@@ -66,6 +76,55 @@ public class RestAuthenticationController {
                     userDetailsService.loadUserByUsername(login.getUsername())
                 )
             );
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(e.getMessage());
+        }
+    }
+
+    /**
+     * User wants to authenticate and get a JWT for a specific role.
+     * <br><br>
+     * An example for this might be someone who is a mobile user granted ROLE_USER and ROLE_ADMIN.
+     * The user wants the extended expiration for their JWT using ROLE_USER, so thsi endpoint allows
+     * them to specify which role they want to authenticate for.
+     *
+     * @param login User Login DTO
+     * @param role Role to authenticate for
+     * @return ResponseEntity containing the String JWT
+     */
+    @PostMapping("/{role}")
+    public ResponseEntity<String> authenticateForRole(@RequestBody LoginDTO login, @PathVariable String role) {
+        // Have to surround in a try/catch, otherwise Spring will follow default security response
+        try {
+            Authentication authentication = authenticationManager.authenticate(
+                new UsernamePasswordAuthenticationToken(login.getUsername(), login.getPassword())
+            );
+
+            if (!authentication.isAuthenticated()) {
+                throw new UsernameNotFoundException("Invalid Credentials");
+            }
+
+            UserDetails userDetails = userDetailsService.loadUserByUsername(login.getUsername());
+
+            // Remove all roles that do not match the requested role
+            String prefixedRole = "ROLE_" + role;
+            List<GrantedAuthority> authorities = userDetails.getAuthorities().stream()
+                .filter(grantedRole -> grantedRole.getAuthority().equalsIgnoreCase(prefixedRole))
+                .collect(Collectors.toList());
+
+            if (authorities.isEmpty()) {
+                // They either requested a role that doesn't exist or are not authorized for that role
+                return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+            }
+
+            UserDetails modifiedUser = User.builder()
+                .username(userDetails.getUsername())
+                .password(userDetails.getPassword())
+                .authorities(authorities)
+                .build();
+
+            return ResponseEntity.ok(jwtService.generateToken(modifiedUser));
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                 .body(e.getMessage());


### PR DESCRIPTION
We want to add an endpoint to allow a user to authenticate for a specific role. Currently, we issue the most restrictive expiration depending on the list of roles granted. For example, if a mobile user has ROLE_USER and ROLE_ADMIN, they will get a JWT that expires in 30 minutes, which would be inconvenient. This endpoint will give them the ability to get the extended 30 day expiration and ONLY be granted a ROLE_USER authority JWT.