### PR TITLE
Make sure there is always at least one admin

### DIFF
--- a/src/main/java/com/damienwesterman/defensedrill/security/service/UserService.java
+++ b/src/main/java/com/damienwesterman/defensedrill/security/service/UserService.java
@@ -153,6 +153,22 @@ public class UserService {
      * @param id User ID.
      */
     public void delete(@NonNull Long id) {
+        Optional<UserEntity> optUser = repo.findById(id);
+        if (optUser.isEmpty()) {
+            // User doesn't exist anyway
+            return;
+        }
+        UserEntity user = optUser.get();
+
+        // Make sure we are not removing the last admin
+        List<UserEntity> admins = findAllByRole(UserRoles.ADMIN.getStringRepresentation());
+        if (1 == admins.size()) {
+            if (admins.get(0).getName().equals(user.getName())) {
+                // This operation would otherwise delete the last remaining admin, so stop it
+                throw new DatabaseInsertException("Cannot remove the last admin");
+            }
+        }
+
         repo.deleteById(id);
     }
 

--- a/src/main/java/com/damienwesterman/defensedrill/security/service/UserService.java
+++ b/src/main/java/com/damienwesterman/defensedrill/security/service/UserService.java
@@ -39,6 +39,7 @@ import com.damienwesterman.defensedrill.security.entity.UserEntity;
 import com.damienwesterman.defensedrill.security.exception.DatabaseInsertException;
 import com.damienwesterman.defensedrill.security.repository.UserRepository;
 import com.damienwesterman.defensedrill.security.util.Constants;
+import com.damienwesterman.defensedrill.security.util.Constants.UserRoles;
 
 import lombok.RequiredArgsConstructor;
 
@@ -133,6 +134,16 @@ public class UserService {
             throw new DatabaseInsertException("Roles are not valid");
         }
 
+        // Make sure we are not removing the last admin
+        List<UserEntity> admins = findAllByRole(UserRoles.ADMIN.getStringRepresentation());
+        if (1 == admins.size()) {
+            if (admins.get(0).getName().equals(user.getName())
+                    && !hasAdminRole(user.getRoles())) {
+                // This operation would otherwise delete the last remaining admin, so stop it
+                throw new DatabaseInsertException("Cannot remove the last admin");
+            }
+        }
+
         return ErrorMessageUtils.trySave(user, repo);
     }
 
@@ -161,5 +172,21 @@ public class UserService {
 
         // Check if each role in rolesList is in the ALL_ROLES_LIST
         return Constants.ALL_ROLES_LIST.containsAll(rolesList);
+    }
+
+    /**
+     * Check if a user's list of roles contains the Admin role.
+     *
+     * @param roles String representation of a comma separated list of roles.
+     * @return true/false if the user is granted the Admin role.
+     */
+    private boolean hasAdminRole(@NonNull String roles) {
+        if (roles.isBlank()) {
+            return false;
+        }
+
+        List<String> rolesList = List.of(roles.split(","));
+
+        return rolesList.contains(UserRoles.ADMIN.getStringRepresentation());
     }
 }

--- a/src/main/java/com/damienwesterman/defensedrill/security/service/UserService.java
+++ b/src/main/java/com/damienwesterman/defensedrill/security/service/UserService.java
@@ -137,7 +137,7 @@ public class UserService {
         // Make sure we are not removing the last admin
         List<UserEntity> admins = findAllByRole(UserRoles.ADMIN.getStringRepresentation());
         if (1 == admins.size()) {
-            if (admins.get(0).getName().equals(user.getName())
+            if (admins.get(0).getId().equals(user.getId())
                     && !hasAdminRole(user.getRoles())) {
                 // This operation would otherwise delete the last remaining admin, so stop it
                 throw new DatabaseInsertException("Cannot remove the last admin");
@@ -153,17 +153,10 @@ public class UserService {
      * @param id User ID.
      */
     public void delete(@NonNull Long id) {
-        Optional<UserEntity> optUser = repo.findById(id);
-        if (optUser.isEmpty()) {
-            // User doesn't exist anyway
-            return;
-        }
-        UserEntity user = optUser.get();
-
         // Make sure we are not removing the last admin
         List<UserEntity> admins = findAllByRole(UserRoles.ADMIN.getStringRepresentation());
         if (1 == admins.size()) {
-            if (admins.get(0).getName().equals(user.getName())) {
+            if (admins.get(0).getId().equals(id)) {
                 // This operation would otherwise delete the last remaining admin, so stop it
                 throw new DatabaseInsertException("Cannot remove the last admin");
             }

--- a/src/main/java/com/damienwesterman/defensedrill/security/web/RestAuthenticationController.java
+++ b/src/main/java/com/damienwesterman/defensedrill/security/web/RestAuthenticationController.java
@@ -51,9 +51,10 @@ import com.damienwesterman.defensedrill.security.web.dto.LoginDTO;
 import lombok.RequiredArgsConstructor;
 
 @RestController
+@RequestMapping(RestAuthenticationController.ENDPOINT)
 @RequiredArgsConstructor
-@RequestMapping("/authenticate")
 public class RestAuthenticationController {
+    private static final String ENDPOINT = "/authenticate";
 
     private final JwtService jwtService;
     private final AuthenticationManager authenticationManager;

--- a/src/main/java/com/damienwesterman/defensedrill/security/web/UsersController.java
+++ b/src/main/java/com/damienwesterman/defensedrill/security/web/UsersController.java
@@ -109,7 +109,7 @@ public class UsersController {
 
     @PostMapping("/id/{id}")
     public ResponseEntity<UserInfoDTO> updateUserById(@PathVariable Long id,
-            @RequestBody UserFormDTO user) {
+            @RequestBody @Valid UserFormDTO user) {
         if (service.find(id).isEmpty()) {
             return ResponseEntity.notFound().build();
         }


### PR DESCRIPTION
We want to make sure that there is always at least one admin in the database:
- Make sure the last admin is not accidentally removed during an update operation
- Make sure the last admin is not accidentally deleted
   - This is supported by changes in DefenseDrillMVC [PR#7](https://github.com/DamienWesterman/DefenseDrillMVC/pull/7)